### PR TITLE
Documentation: Added Connect() Example to README; Updated In-line Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,27 @@ go get code.google.com/p/goprotobuf/{proto,protoc-gen-go}
 
 ### Basic Connection
 
-TODO: Add instructions for basic connections
+Setting up a basic connection with RethinkDB is simple:
+
+```go
+import (
+    r "github.com/dancannon/gorethink"
+)
+
+var session *r.Session
+
+session, err := r.Connect(map[string]interface{}{
+        "address":  "localhost:28015",
+        "database": "test",
+        "authkey":  "14daak1cad13dj",
+    })
+
+    if err != nil {
+        log.Fatalln(err.Error())
+    }
+
+```
+See the [documentation](http://godoc.org/github.com/dancannon/gorethink#Connect) for a list of supported arguments to Connect().
 
 ### Connection Pool
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,29 @@ See the [documentation](http://godoc.org/github.com/dancannon/gorethink#Connect)
 
 ### Connection Pool
 
-TODO: Add instructions for basic connections
+The driver uses a connection pool at all times, however by default there is only a single connection available. In order to turn this into a proper connection pool, we need to pass the `maxIdle`, `maxActive` and/or `idleTimeout` parameters to Connect():
+
+```go
+import (
+    r "github.com/dancannon/gorethink"
+)
+
+var session *r.Session
+
+session, err := r.Connect(map[string]interface{}{
+        "address":  "localhost:28015",
+        "database": "test",
+        "maxIdle": 10,
+        "maxActive": 30,
+        "idleTimeout": time.Second * 10,
+    })
+
+    if err != nil {
+        log.Fatalln(err.Error())
+    }
+```
+
+A pre-configured [Pool](http://godoc.org/github.com/dancannon/gorethink#Pool) instance can also be passed to Connect().
 
 ## Query Functions
 

--- a/session.go
+++ b/session.go
@@ -63,6 +63,19 @@ func newSession(args map[string]interface{}) *Session {
 }
 
 // Connect creates a new database session.
+//
+// Supported arguments include token, address, database, timeout, authkey,
+// and timeFormat. Pool options (when using the included connection pool manager)
+// include maxIdle, maxActive and idleTimeout.
+//
+// Example usage:
+//
+// var session *r.Session
+// session, err := r.Connect(map[string]interface{}{
+//        	"address":  "localhost:28015",
+//       	"database": "test",
+//        	"authkey":  "14daak1cad13dj",
+//    })
 func Connect(args map[string]interface{}) (*Session, error) {
 	s := newSession(args)
 	err := s.Reconnect()

--- a/session.go
+++ b/session.go
@@ -65,10 +65,13 @@ func newSession(args map[string]interface{}) *Session {
 // Connect creates a new database session.
 //
 // Supported arguments include token, address, database, timeout, authkey,
-// and timeFormat. Pool options (when using the included connection pool manager)
-// include maxIdle, maxActive and idleTimeout.
+// and timeFormat. Pool options include maxIdle, maxActive and idleTimeout.
 //
-// Example usage:
+// By default maxIdle and maxActive are set to 1: passing values greater
+// than the default (e.g. maxIdle: "10", maxActive: "20") will provide a
+// pool of re-usable connections.
+//
+// Basic connection example:
 //
 // var session *r.Session
 // session, err := r.Connect(map[string]interface{}{


### PR DESCRIPTION
I've added a basic connection example to the README, and have also updated the in-line documentation for Connect() to show the supported arguments more clearly (to avoid having to dig into the source code). Godoc should pick it up and display it beneath the function signature.

I'm also planning to do the same for connection pooling (README example + in-line docs) but I need to figure out a simple example before doing so (tips appreciated!).

Let me know if you want this squashed into a single commit.
