### PR TITLE
Add ResultRow.IsNil() + ResultRows.IsNil() + minor doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,12 @@ Both ResultRows and ResultRow have the function `Scan` which is used to bind a r
 Example:
 
 ```go
-row := Expr("Hello World").RunRow(conn)
-
-var response interface{}
-err := row.Scan(&response)
+row := Table("tablename").Get(key).RunRow(conn)
+// Check if something was found
+if !row.IsNil() {
+	var response interface{}
+	err := row.Scan(&response)
+}
 ```
 
 ResultRows also has the function `Next` which is used to iterate through a result set. If a partial sequence is returned by the server Next will automatically fetch the result of the sequence.

--- a/query_select.go
+++ b/query_select.go
@@ -23,7 +23,7 @@ func (t RqlTerm) Table(name interface{}, optArgs ...interface{}) RqlTerm {
 	return newRqlTermFromPrevVal(t, "Table", p.Term_TABLE, []interface{}{name}, optArgM)
 }
 
-// Get a document by primary key.
+// Get a document by primary key. If nothing was found, RethinkDB will return a nil value.
 func (t RqlTerm) Get(key interface{}) RqlTerm {
 	return newRqlTermFromPrevVal(t, "Get", p.Term_GET, []interface{}{key}, map[string]interface{}{})
 }

--- a/results_test.go
+++ b/results_test.go
@@ -142,4 +142,8 @@ func (s *RethinkSuite) TestEmptyResults(c *test.C) {
 	c.Assert(err, test.IsNil)
 	rows.Next()
 	c.Assert(rows.IsNil(), test.Equals, true)
+
+	rows, err = Db("test").Table("test").GetAll("missing value", "another missing value").Run(sess)
+	c.Assert(err, test.IsNil)
+	c.Assert(rows.Next(), test.Equals, false)
 }

--- a/results_test.go
+++ b/results_test.go
@@ -126,3 +126,20 @@ func (s *RethinkSuite) TestRowsAtomArray(c *test.C) {
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.DeepEquals, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 0})
 }
+
+func (s *RethinkSuite) TestEmptyResults(c *test.C) {
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
+	row := Db("test").Table("test").Get("missing value").RunRow(sess)
+	c.Assert(row.IsNil(), test.Equals, true)
+
+	row = Db("test").Table("test").Get("missing value").RunRow(sess)
+	var response interface{}
+	row.Scan(response)
+	c.Assert(row.IsNil(), test.Equals, true)
+
+	rows, err := Db("test").Table("test").Get("missing value").Run(sess)
+	c.Assert(err, test.IsNil)
+	rows.Next()
+	c.Assert(rows.IsNil(), test.Equals, true)
+}


### PR DESCRIPTION
Fix for #11

```
row := r.Table(table).Get("missing key").RunRow(rs)
if !row.IsNil() {
    err := row.Scan(obj)
}

rows, err := r.Table(table).Get("missing key").Run(rs)
for rows.Next() && !rows.IsNil() {
    err := rows.Scan(obj)
}
```

I did not add rows.IsEmpty() because I found it simpler to test if the current row is nil.
