### PR TITLE
[BC break] Have RunRow return (*ResultRow, error) instead of *ResultRow

### DIFF
--- a/query_aggregation_test.go
+++ b/query_aggregation_test.go
@@ -9,8 +9,10 @@ func (s *RethinkSuite) TestAggregationReduce(c *test.C) {
 	query := Expr(arr).Reduce(func(acc, val RqlTerm) RqlTerm {
 		return acc.Add(val)
 	}, 0)
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
 
+	err = r.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, 45)
 }
@@ -18,7 +20,10 @@ func (s *RethinkSuite) TestAggregationReduce(c *test.C) {
 func (s *RethinkSuite) TestAggregationExprCount(c *test.C) {
 	var response int
 	query := Expr(arr).Count()
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, 9)
@@ -27,7 +32,10 @@ func (s *RethinkSuite) TestAggregationExprCount(c *test.C) {
 func (s *RethinkSuite) TestAggregationDistinct(c *test.C) {
 	var response []int
 	query := Expr(darr).Distinct()
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.HasLen, 5)
@@ -47,7 +55,10 @@ func (s *RethinkSuite) TestAggregationGroupedMapReduce(c *test.C) {
 		},
 		0,
 	)
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -78,7 +89,10 @@ func (s *RethinkSuite) TestAggregationGroupedMapReduceTable(c *test.C) {
 		},
 		0,
 	)
-	err = query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -90,7 +104,10 @@ func (s *RethinkSuite) TestAggregationGroupedMapReduceTable(c *test.C) {
 func (s *RethinkSuite) TestAggregationGroupByCount(c *test.C) {
 	var response interface{}
 	query := Expr(objList).GroupBy(Count(), "g1")
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -104,7 +121,10 @@ func (s *RethinkSuite) TestAggregationGroupByCount(c *test.C) {
 func (s *RethinkSuite) TestAggregationGroupBySum(c *test.C) {
 	var response interface{}
 	query := Expr(objList).GroupBy(Sum("num"), "g1")
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -118,7 +138,10 @@ func (s *RethinkSuite) TestAggregationGroupBySum(c *test.C) {
 func (s *RethinkSuite) TestAggregationGroupByAvg(c *test.C) {
 	var response interface{}
 	query := Expr(objList).GroupBy(Avg("num"), "g1")
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -132,7 +155,10 @@ func (s *RethinkSuite) TestAggregationGroupByAvg(c *test.C) {
 func (s *RethinkSuite) TestAggregationGroupBySumMultipleSelectors(c *test.C) {
 	var response interface{}
 	query := Expr(objList).GroupBy(Sum("num"), "g1", "g2")
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -148,7 +174,10 @@ func (s *RethinkSuite) TestAggregationGroupBySumMultipleSelectors(c *test.C) {
 func (s *RethinkSuite) TestAggregationContains(c *test.C) {
 	var response interface{}
 	query := Expr(arr).Contains(2)
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)

--- a/query_control_test.go
+++ b/query_control_test.go
@@ -7,7 +7,10 @@ import (
 func (s *RethinkSuite) TestControlExecSimple(c *test.C) {
 	var response int
 	query := Expr(1)
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, 1)
@@ -16,7 +19,10 @@ func (s *RethinkSuite) TestControlExecSimple(c *test.C) {
 func (s *RethinkSuite) TestControlExecList(c *test.C) {
 	var response []interface{}
 	query := Expr(narr)
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -29,7 +35,10 @@ func (s *RethinkSuite) TestControlExecList(c *test.C) {
 func (s *RethinkSuite) TestControlExecObj(c *test.C) {
 	var response map[string]interface{}
 	query := Expr(nobj)
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{
@@ -45,7 +54,10 @@ func (s *RethinkSuite) TestControlExecObj(c *test.C) {
 func (s *RethinkSuite) TestControlStruct(c *test.C) {
 	var response map[string]interface{}
 	query := Expr(str)
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{
@@ -80,7 +92,10 @@ func (s *RethinkSuite) TestControlStruct(c *test.C) {
 func (s *RethinkSuite) TestControlMapTypeAlias(c *test.C) {
 	var response TMap
 	query := Expr(TMap{"A": 1, "B": 2})
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, TMap{"A": 1, "B": 2})
@@ -89,7 +104,10 @@ func (s *RethinkSuite) TestControlMapTypeAlias(c *test.C) {
 func (s *RethinkSuite) TestControlStringTypeAlias(c *test.C) {
 	var response TStr
 	query := Expr(TStr("Hello"))
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, TStr("Hello"))
@@ -98,7 +116,10 @@ func (s *RethinkSuite) TestControlStringTypeAlias(c *test.C) {
 func (s *RethinkSuite) TestControlExecTypes(c *test.C) {
 	var response []interface{}
 	query := Expr([]interface{}{int64(1), uint64(1), float64(1.0), int32(1), uint32(1), float32(1), "1", true, false})
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{int64(1), uint64(1), float64(1.0), int32(1), uint32(1), float32(1), "1", true, false})
@@ -107,7 +128,10 @@ func (s *RethinkSuite) TestControlExecTypes(c *test.C) {
 func (s *RethinkSuite) TestControlJs(c *test.C) {
 	var response int
 	query := Js("1;")
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, 1)
@@ -116,7 +140,10 @@ func (s *RethinkSuite) TestControlJs(c *test.C) {
 func (s *RethinkSuite) TestControlJson(c *test.C) {
 	var response []int
 	query := Json("[1,2,3]")
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 2, 3})
@@ -125,7 +152,10 @@ func (s *RethinkSuite) TestControlJson(c *test.C) {
 func (s *RethinkSuite) TestControlError(c *test.C) {
 	var response []interface{}
 	query := Error("An error occurred")
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.NotNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.NotNil)
 	c.Assert(err, test.FitsTypeOf, RqlRuntimeError{})
@@ -135,7 +165,10 @@ func (s *RethinkSuite) TestControlError(c *test.C) {
 func (s *RethinkSuite) TestControlDoNothing(c *test.C) {
 	var response []interface{}
 	query := Do([]interface{}{map[string]interface{}{"a": 1}, map[string]interface{}{"a": 2}, map[string]interface{}{"a": 3}})
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{map[string]interface{}{"a": 1}, map[string]interface{}{"a": 2}, map[string]interface{}{"a": 3}})
@@ -150,7 +183,10 @@ func (s *RethinkSuite) TestControlDo(c *test.C) {
 	}, func(row RqlTerm) RqlTerm {
 		return row.Field("a")
 	})
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 2, 3})
@@ -165,7 +201,10 @@ func (s *RethinkSuite) TestControlDoWithExpr(c *test.C) {
 	}).Do(func(row RqlTerm) RqlTerm {
 		return row.Field("a")
 	})
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 2, 3})
@@ -178,7 +217,10 @@ func (s *RethinkSuite) TestControlBranchSimple(c *test.C) {
 		1,
 		2,
 	)
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, 1)
@@ -191,7 +233,10 @@ func (s *RethinkSuite) TestControlBranchWithMapExpr(c *test.C) {
 		Row.Sub(1),
 		Row.Add(1),
 	))
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{2, 1, 4})
@@ -202,7 +247,10 @@ func (s *RethinkSuite) TestControlDefault(c *test.C) {
 	query := Expr(defaultObjList).Map(func(row RqlTerm) RqlTerm {
 		return row.Field("a").Default(1)
 	})
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 1})
@@ -211,7 +259,10 @@ func (s *RethinkSuite) TestControlDefault(c *test.C) {
 func (s *RethinkSuite) TestControlCoerceTo(c *test.C) {
 	var response string
 	query := Expr(1).CoerceTo("STRING")
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, "1")
@@ -220,7 +271,10 @@ func (s *RethinkSuite) TestControlCoerceTo(c *test.C) {
 func (s *RethinkSuite) TestControlTypeOf(c *test.C) {
 	var response string
 	query := Expr(1).TypeOf()
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, "NUMBER")

--- a/query_db_test.go
+++ b/query_db_test.go
@@ -13,7 +13,10 @@ func (s *RethinkSuite) TestDbCreate(c *test.C) {
 	// Test database creation
 	query := DbCreate("test")
 
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"created": 1})
@@ -27,7 +30,10 @@ func (s *RethinkSuite) TestDbList(c *test.C) {
 
 	// Try and find it in the list
 	success := false
-	err := DbList().RunRow(sess).Scan(&response)
+	r, err := DbList().RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.FitsTypeOf, []interface{}{})
@@ -50,7 +56,10 @@ func (s *RethinkSuite) TestDbDelete(c *test.C) {
 	// Test database creation
 	query := DbDrop("test")
 
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"dropped": 1})

--- a/query_manipulation_test.go
+++ b/query_manipulation_test.go
@@ -8,7 +8,10 @@ func (s *RethinkSuite) TestManipulationDocField(c *test.C) {
 	query := Expr(map[string]interface{}{"a": 1}).Do(Row.Field("a"))
 
 	var response int
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, 1)
@@ -18,7 +21,10 @@ func (s *RethinkSuite) TestManipulationPluck(c *test.C) {
 	query := Expr(map[string]interface{}{"a": 1, "b": 2, "c": 3}).Pluck("a", "c")
 
 	var response map[string]interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"a": 1, "c": 3})
@@ -28,7 +34,10 @@ func (s *RethinkSuite) TestManipulationWithout(c *test.C) {
 	query := Expr(map[string]interface{}{"a": 1, "b": 2, "c": 3}).Pluck("a", "c")
 
 	var response map[string]interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"a": 1, "c": 3})
@@ -38,7 +47,10 @@ func (s *RethinkSuite) TestManipulationMerge(c *test.C) {
 	query := Expr(map[string]interface{}{"a": 1, "c": 3}).Merge(map[string]interface{}{"b": 2})
 
 	var response map[string]interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"a": 1, "b": 2, "c": 3})
@@ -59,7 +71,10 @@ func (s *RethinkSuite) TestManipulationMergeLiteral(c *test.C) {
 	}).Merge(map[string]interface{}{"a": map[string]interface{}{"ab": Literal()}})
 
 	var response map[string]interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"a": map[string]interface{}{"aa": map[string]interface{}{"aab": 2, "aaa": 1}}})
@@ -69,7 +84,10 @@ func (s *RethinkSuite) TestManipulationAppend(c *test.C) {
 	query := Expr([]interface{}{1, 2, 3}).Append(4).Append(5)
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 2, 3, 4, 5})
@@ -79,7 +97,10 @@ func (s *RethinkSuite) TestManipulationPrepend(c *test.C) {
 	query := Expr([]interface{}{3, 4, 5}).Prepend(2).Prepend(1)
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 2, 3, 4, 5})
@@ -89,7 +110,10 @@ func (s *RethinkSuite) TestManipulationDifference(c *test.C) {
 	query := Expr([]interface{}{3, 4, 5}).Difference([]interface{}{3, 4})
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{5})
@@ -99,7 +123,10 @@ func (s *RethinkSuite) TestManipulationSetInsert(c *test.C) {
 	query := Expr([]interface{}{1, 2, 3}).SetInsert(3).SetInsert(4)
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 2, 3, 4})
@@ -109,7 +136,10 @@ func (s *RethinkSuite) TestManipulationSetUnion(c *test.C) {
 	query := Expr([]interface{}{1, 2, 3}).SetUnion([]interface{}{3, 4})
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 2, 3, 4})
@@ -119,7 +149,10 @@ func (s *RethinkSuite) TestManipulationSetIntersection(c *test.C) {
 	query := Expr([]interface{}{1, 2, 3}).SetIntersection([]interface{}{2, 3, 3, 4})
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{2, 3})
@@ -129,7 +162,10 @@ func (s *RethinkSuite) TestManipulationSetDifference(c *test.C) {
 	query := Expr([]interface{}{1, 2, 3}).SetDifference([]interface{}{2, 3, 4, 4})
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1})
@@ -139,7 +175,10 @@ func (s *RethinkSuite) TestManipulationHasFieldsTrue(c *test.C) {
 	query := Expr(map[string]interface{}{"a": 1}).HasFields("a")
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -149,7 +188,10 @@ func (s *RethinkSuite) TestManipulationHasFieldsNested(c *test.C) {
 	query := Expr(map[string]interface{}{"a": map[string]interface{}{"b": 1}}).HasFields(map[string]interface{}{"a": map[string]interface{}{"b": true}})
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -159,7 +201,10 @@ func (s *RethinkSuite) TestManipulationHasFieldsNestedShort(c *test.C) {
 	query := Expr(map[string]interface{}{"a": map[string]interface{}{"b": 1}}).HasFields(map[string]interface{}{"a": "b"})
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -169,7 +214,10 @@ func (s *RethinkSuite) TestManipulationHasFieldsFalse(c *test.C) {
 	query := Expr(map[string]interface{}{"a": 1}).HasFields("b")
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, false)
@@ -179,7 +227,10 @@ func (s *RethinkSuite) TestManipulationInsertAt(c *test.C) {
 	query := Expr([]interface{}{1, 2, 3}).InsertAt(1, 1.5)
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 1.5, 2, 3})
@@ -189,7 +240,10 @@ func (s *RethinkSuite) TestManipulationSpliceAt(c *test.C) {
 	query := Expr([]interface{}{1, 2, 3}).SpliceAt(1, []interface{}{1.25, 1.5, 1.75})
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 1.25, 1.5, 1.75, 2, 3})
@@ -199,7 +253,10 @@ func (s *RethinkSuite) TestManipulationDeleteAt(c *test.C) {
 	query := Expr([]interface{}{1, 2, 3}).DeleteAt(1)
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 3})
@@ -209,7 +266,10 @@ func (s *RethinkSuite) TestManipulationDeleteAtRange(c *test.C) {
 	query := Expr([]interface{}{1, 2, 3, 4}).DeleteAtRange(1, 3)
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 4})
@@ -219,7 +279,10 @@ func (s *RethinkSuite) TestManipulationChangeAt(c *test.C) {
 	query := Expr([]interface{}{1, 5, 3, 4}).ChangeAt(1, 2)
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 2, 3, 4})
@@ -229,7 +292,10 @@ func (s *RethinkSuite) TestManipulationKeys(c *test.C) {
 	query := Expr(map[string]interface{}{"a": 1, "b": 2, "c": 3}).Keys()
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{"a", "b", "c"})

--- a/query_math_test.go
+++ b/query_math_test.go
@@ -8,7 +8,10 @@ func (s *RethinkSuite) TestMathAdd(c *test.C) {
 	query := Expr(1).Add(2)
 
 	var response int
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, 3)
@@ -18,7 +21,10 @@ func (s *RethinkSuite) TestMathSub(c *test.C) {
 	query := Expr(2).Sub(1)
 
 	var response int
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, 1)
@@ -28,7 +34,10 @@ func (s *RethinkSuite) TestMathSubNegative(c *test.C) {
 	query := Expr(1).Sub(2)
 
 	var response int
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, -1)
@@ -38,7 +47,10 @@ func (s *RethinkSuite) TestMathMul(c *test.C) {
 	query := Expr(5).Mul(4)
 
 	var response int
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, 20)
@@ -48,7 +60,10 @@ func (s *RethinkSuite) TestMathDiv(c *test.C) {
 	query := Expr(8).Div(4)
 
 	var response int
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, 2)
@@ -58,7 +73,10 @@ func (s *RethinkSuite) TestMathMod(c *test.C) {
 	query := Expr(7).Mod(2)
 
 	var response int
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, 1)
@@ -68,7 +86,10 @@ func (s *RethinkSuite) TestMathEqTrue(c *test.C) {
 	query := Expr(1).Eq(1)
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -78,7 +99,10 @@ func (s *RethinkSuite) TestMathEqFalse(c *test.C) {
 	query := Expr(1).Eq(2)
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, false)
@@ -88,7 +112,10 @@ func (s *RethinkSuite) TestMathEqStringTrue(c *test.C) {
 	query := Expr("test").Eq("test")
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -98,7 +125,10 @@ func (s *RethinkSuite) TestCompareLt(c *test.C) {
 	query := Expr(2).Lt(1)
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, false)
@@ -108,7 +138,10 @@ func (s *RethinkSuite) TestCompareLe(c *test.C) {
 	query := Expr(2).Le(1)
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, false)
@@ -118,7 +151,10 @@ func (s *RethinkSuite) TestCompareLeEqual(c *test.C) {
 	query := Expr(2).Le(2)
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -128,7 +164,10 @@ func (s *RethinkSuite) TestCompareGt(c *test.C) {
 	query := Expr(2).Gt(1)
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -138,7 +177,10 @@ func (s *RethinkSuite) TestCompareGe(c *test.C) {
 	query := Expr(2).Ge(1)
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -148,7 +190,10 @@ func (s *RethinkSuite) TestCompareGeEqual(c *test.C) {
 	query := Expr(2).Le(2)
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -158,7 +203,10 @@ func (s *RethinkSuite) TestBoolNotTrue(c *test.C) {
 	query := Expr(true).Not()
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, false)
@@ -168,7 +216,10 @@ func (s *RethinkSuite) TestBoolAnd(c *test.C) {
 	query := Expr(true).And(true)
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -178,7 +229,10 @@ func (s *RethinkSuite) TestBoolOr(c *test.C) {
 	query := Expr(true).Or(false)
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -188,7 +242,10 @@ func (s *RethinkSuite) TestBoolDeMorgan(c *test.C) {
 	query := Expr(true).And(false).Eq(Expr(true).Not().Or(Expr(false).Not()).Not())
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)

--- a/query_select_test.go
+++ b/query_select_test.go
@@ -15,7 +15,10 @@ func (s *RethinkSuite) TestSelectGet(c *test.C) {
 	// Test query
 	var response interface{}
 	query := Db("test").Table("Table1").Get(6)
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"id": 6, "g1": 1, "g2": 1, "num": 15})
@@ -79,7 +82,10 @@ func (s *RethinkSuite) TestSelectGetAllByIndex(c *test.C) {
 	// Test query
 	var response interface{}
 	query := Db("test").Table("Table1").GetAllByIndex("num", 15).OrderBy("id")
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"id": 6, "g1": 1, "g2": 1, "num": 15})
@@ -97,7 +103,10 @@ func (s *RethinkSuite) TestSelectGetAllMultipleByIndex(c *test.C) {
 	// Test query
 	var response interface{}
 	query := Db("test").Table("Table2").GetAllByIndex("num", 15).OrderBy("id")
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"id": 6, "g1": 1, "g2": 1, "num": 15})

--- a/query_string_test.go
+++ b/query_string_test.go
@@ -8,7 +8,10 @@ func (s *RethinkSuite) TestStringMatchSuccess(c *test.C) {
 	query := Expr("id:0,name:mlucy,foo:bar").Match("name:(\\w+)").Field("groups").Nth(0).Field("str")
 
 	var response string
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, "mlucy")
@@ -18,7 +21,10 @@ func (s *RethinkSuite) TestStringMatchFail(c *test.C) {
 	query := Expr("id:0,foo:bar").Match("name:(\\w+)").Field("groups").Nth(0).Field("str")
 
 	var response int
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.NotNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.NotNil)
 }

--- a/query_table_test.go
+++ b/query_table_test.go
@@ -12,7 +12,10 @@ func (s *RethinkSuite) TestTableCreate(c *test.C) {
 	// Test database creation
 	query := Db("test").TableCreate("test")
 
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"created": 1})
@@ -28,7 +31,10 @@ func (s *RethinkSuite) TestTableCreatePrimaryKey(c *test.C) {
 		"primary_key", "it",
 	)
 
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"created": 1})
@@ -44,7 +50,10 @@ func (s *RethinkSuite) TestTableCreateSoftDurability(c *test.C) {
 		"durability", "soft",
 	)
 
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"created": 1})
@@ -61,7 +70,10 @@ func (s *RethinkSuite) TestTableCreateSoftMultipleOpts(c *test.C) {
 		"durability", "soft",
 	)
 
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"created": 1})
@@ -76,7 +88,10 @@ func (s *RethinkSuite) TestTableList(c *test.C) {
 
 	// Try and find it in the list
 	success := false
-	err := Db("test").TableList().RunRow(sess).Scan(&response)
+	row, err := Db("test").TableList().RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	row.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.FitsTypeOf, []interface{}{})
@@ -98,7 +113,10 @@ func (s *RethinkSuite) TestTableDelete(c *test.C) {
 	// Test database creation
 	query := Db("test").TableDrop("test")
 
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"dropped": 1})
@@ -113,7 +131,10 @@ func (s *RethinkSuite) TestTableIndexCreate(c *test.C) {
 	// Test database creation
 	query := Db("test").Table("test").IndexCreate("test")
 
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"created": 1})
@@ -127,7 +148,10 @@ func (s *RethinkSuite) TestTableIndexList(c *test.C) {
 
 	// Try and find it in the list
 	success := false
-	err := Db("test").Table("test").IndexList().RunRow(sess).Scan(&response)
+	row, err := Db("test").Table("test").IndexList().RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = row.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.FitsTypeOf, []interface{}{})
@@ -150,7 +174,10 @@ func (s *RethinkSuite) TestTableIndexDelete(c *test.C) {
 	// Test database creation
 	query := Db("test").Table("test").IndexDrop("test")
 
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{"dropped": 1})

--- a/query_test.go
+++ b/query_test.go
@@ -7,7 +7,10 @@ import (
 func (s *RethinkSuite) TestQueryRun(c *test.C) {
 	var response string
 
-	err := Expr("Test").RunRow(sess).Scan(&response)
+	row, err := Expr("Test").RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = row.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, "Test")
@@ -16,7 +19,10 @@ func (s *RethinkSuite) TestQueryRun(c *test.C) {
 func (s *RethinkSuite) TestQueryRunRawTime(c *test.C) {
 	var response map[string]interface{}
 
-	err := Now().RunRow(sess, "time_format", "raw").Scan(&response)
+	row, err := Now().RunRow(sess, "time_format", "raw")
+	c.Assert(err, test.IsNil)
+
+	err = row.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response["$reql_type$"], test.NotNil)

--- a/query_time_test.go
+++ b/query_time_test.go
@@ -7,14 +7,20 @@ import (
 
 func (s *RethinkSuite) TestTimeTime(c *test.C) {
 	var response time.Time
-	err := Time(1986, 11, 3, 12, 30, 15, "Z").RunRow(sess).Scan(&response)
+	row, err := Time(1986, 11, 3, 12, 30, 15, "Z").RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = row.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response.Equal(time.Date(1986, 11, 3, 12, 30, 15, 0, time.UTC)), test.Equals, true)
 }
 
 func (s *RethinkSuite) TestTimeEpochTime(c *test.C) {
 	var response time.Time
-	err := EpochTime(531360000).RunRow(sess).Scan(&response)
+	row, err := EpochTime(531360000).RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = row.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response.Equal(time.Date(1986, 11, 3, 0, 0, 0, 0, time.UTC)), test.Equals, true)
 }
@@ -22,7 +28,10 @@ func (s *RethinkSuite) TestTimeEpochTime(c *test.C) {
 func (s *RethinkSuite) TestTimeISO8601(c *test.C) {
 	var t1, t2 time.Time
 	t2, _ = time.Parse("2006-01-02T15:04:05-07:00", "1986-11-03T08:30:00-07:00")
-	err := ISO8601("1986-11-03T08:30:00-07:00").RunRow(sess).Scan(&t1)
+	row, err := ISO8601("1986-11-03T08:30:00-07:00").RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = row.Scan(&t1)
 	c.Assert(err, test.IsNil)
 	c.Assert(t1.Equal(t2), test.Equals, true)
 }
@@ -31,7 +40,10 @@ func (s *RethinkSuite) TestTimeInTimezone(c *test.C) {
 	loc, err := time.LoadLocation("MST")
 	c.Assert(err, test.IsNil)
 	var response []time.Time
-	err = Expr([]interface{}{Now(), Now().InTimezone("-07:00")}).RunRow(sess).Scan(&response)
+	row, err2 := Expr([]interface{}{Now(), Now().InTimezone("-07:00")}).RunRow(sess)
+	c.Assert(err2, test.IsNil)
+
+	err = row.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response[1].Equal(response[0].In(loc)), test.Equals, true)
 }
@@ -45,9 +57,12 @@ func (s *RethinkSuite) TestTimeBetween(c *test.C) {
 		Time(1986, 11, 3, 12, 30, 15, "Z"),
 		Time(1986, 12, 3, 12, 30, 15, "Z"),
 	})
-	err := times.Filter(func(row RqlTerm) RqlTerm {
+	row, err := times.Filter(func(row RqlTerm) RqlTerm {
 		return row.During(Time(1986, 9, 3, 12, 30, 15, "Z"), Time(1986, 11, 3, 12, 30, 15, "Z"))
-	}).Count().RunRow(sess).Scan(&response)
+	}).Count().RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = row.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(int(response.(float64)), test.Equals, 2)
@@ -56,7 +71,10 @@ func (s *RethinkSuite) TestTimeBetween(c *test.C) {
 func (s *RethinkSuite) TestTimeYear(c *test.C) {
 	var response interface{}
 
-	err := Time(1986, 12, 3, 12, 30, 15, "Z").Year().RunRow(sess).Scan(&response)
+	row, err := Time(1986, 12, 3, 12, 30, 15, "Z").Year().RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = row.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(int(response.(float64)), test.Equals, 1986)
@@ -65,7 +83,10 @@ func (s *RethinkSuite) TestTimeYear(c *test.C) {
 func (s *RethinkSuite) TestTimeMonth(c *test.C) {
 	var response interface{}
 
-	err := Time(1986, 12, 3, 12, 30, 15, "Z").Month().Eq(December()).RunRow(sess).Scan(&response)
+	row, err := Time(1986, 12, 3, 12, 30, 15, "Z").Month().Eq(December()).RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = row.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response.(bool), test.Equals, true)
@@ -74,7 +95,10 @@ func (s *RethinkSuite) TestTimeMonth(c *test.C) {
 func (s *RethinkSuite) TestTimeDay(c *test.C) {
 	var response interface{}
 
-	err := Time(1986, 12, 3, 12, 30, 15, "Z").Day().Eq(Wednesday()).RunRow(sess).Scan(&response)
+	row, err := Time(1986, 12, 3, 12, 30, 15, "Z").Day().Eq(Wednesday()).RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = row.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response.(bool), test.Equals, true)

--- a/query_transformation_test.go
+++ b/query_transformation_test.go
@@ -8,7 +8,10 @@ func (s *RethinkSuite) TestTransformationMapImplicit(c *test.C) {
 	query := Expr(arr).Map(Row.Add(1))
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{2, 3, 4, 5, 6, 7, 8, 9, 10})
@@ -20,7 +23,10 @@ func (s *RethinkSuite) TestTransformationMapFunc(c *test.C) {
 	})
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{2, 3, 4, 5, 6, 7, 8, 9, 10})
@@ -30,7 +36,10 @@ func (s *RethinkSuite) TestTransformationWithFields(c *test.C) {
 	query := Expr(objList).WithFields("id", "num").OrderBy("id")
 
 	var response []interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -52,7 +61,10 @@ func (s *RethinkSuite) TestTransformationConcatMap(c *test.C) {
 	})
 
 	var response interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{0, 5, 10, 0, 100, 15, 0, 50, 25})
@@ -62,7 +74,10 @@ func (s *RethinkSuite) TestTransformationOrderByDesc(c *test.C) {
 	query := Expr(noDupNumObjList).OrderBy(Desc("num"))
 
 	var response interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -80,7 +95,10 @@ func (s *RethinkSuite) TestTransformationOrderByAsc(c *test.C) {
 	query := Expr(noDupNumObjList).OrderBy(Asc("num"))
 
 	var response interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -98,7 +116,10 @@ func (s *RethinkSuite) TestTransformationOrderByMultiple(c *test.C) {
 	query := Expr(objList).OrderBy(Desc("num"), Asc("id"))
 
 	var response interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -120,7 +141,10 @@ func (s *RethinkSuite) TestTransformationOrderByFunc(c *test.C) {
 	})
 
 	var response interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{
@@ -140,7 +164,10 @@ func (s *RethinkSuite) TestTransformationSkip(c *test.C) {
 	query := Expr(arr).Skip(7)
 
 	var response interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{8, 9})
@@ -150,7 +177,10 @@ func (s *RethinkSuite) TestTransformationLimit(c *test.C) {
 	query := Expr(arr).Limit(2)
 
 	var response interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 2})
@@ -160,7 +190,10 @@ func (s *RethinkSuite) TestTransformationSlice(c *test.C) {
 	query := Expr(arr).Slice(5, 6)
 
 	var response interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{6})
@@ -170,7 +203,10 @@ func (s *RethinkSuite) TestTransformationNth(c *test.C) {
 	query := Expr(arr).Nth(2)
 
 	var response interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, 3)
@@ -180,7 +216,10 @@ func (s *RethinkSuite) TestTransformationIndexesOf(c *test.C) {
 	query := Expr(arr).IndexesOf(2)
 
 	var response interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1})
@@ -190,7 +229,10 @@ func (s *RethinkSuite) TestTransformationIsEmpty(c *test.C) {
 	query := Expr([]interface{}{}).IsEmpty()
 
 	var response bool
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, true)
@@ -200,7 +242,10 @@ func (s *RethinkSuite) TestTransformationUnion(c *test.C) {
 	query := Expr(arr).Union(arr)
 
 	var response interface{}
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9})

--- a/query_write_test.go
+++ b/query_write_test.go
@@ -23,7 +23,10 @@ func (s *RethinkSuite) TestWriteInsertStruct(c *test.C) {
 	}
 
 	query := Db("test").Table("test").Insert(o)
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response["inserted"], test.Equals, float64(1))
@@ -42,7 +45,10 @@ func (s *RethinkSuite) TestWriteInsertStructPointer(c *test.C) {
 	}
 
 	query := Db("test").Table("test").Insert(&o)
-	err := query.RunRow(sess).Scan(&response)
+	r, err := query.RunRow(sess)
+	c.Assert(err, test.IsNil)
+
+	err = r.Scan(&response)
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response["inserted"], test.Equals, float64(1))

--- a/results.go
+++ b/results.go
@@ -8,7 +8,6 @@ import (
 type ResultRow struct {
 	err     error
 	rows    *ResultRows
-	fetched bool
 }
 
 // Scan copies the result from the matched row into the value pointed at by dest.
@@ -22,19 +21,7 @@ func (r *ResultRow) Scan(dest interface{}) error {
 		return r.err
 	}
 
-	if !r.fetched {
-		r.fetched = true
-		defer r.rows.Close()
-		if !r.rows.Next() {
-			return RqlDriverError{"No rows in the result set"}
-		}
-	}
-	err := r.rows.Scan(dest)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return r.rows.Scan(dest)
 }
 
 // Tests if the result is nil.
@@ -43,15 +30,6 @@ func (r *ResultRow) IsNil() bool {
 	if r.err != nil {
 		return true
 	}
-
-	if !r.fetched {
-		r.fetched = true
-		defer r.rows.Close()
-		if !r.rows.Next() {
-			return true
-		}
-	}
-
 	return r.rows.IsNil()
 }
 

--- a/results_test.go
+++ b/results_test.go
@@ -16,31 +16,34 @@ type attr struct {
 }
 
 func (s *RethinkSuite) TestRowsScanLiteral(c *test.C) {
-	row := Expr(5).RunRow(sess)
+	row, err := Expr(5).RunRow(sess)
+	c.Assert(err, test.IsNil)
 
 	var response interface{}
-	err := row.Scan(&response)
+	err = row.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, 5)
 }
 
 func (s *RethinkSuite) TestRowsScanSlice(c *test.C) {
-	row := Expr([]interface{}{1, 2, 3, 4, 5}).RunRow(sess)
+	row, err := Expr([]interface{}{1, 2, 3, 4, 5}).RunRow(sess)
+	c.Assert(err, test.IsNil)
 
 	var response interface{}
-	err := row.Scan(&response)
+	err = row.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, []interface{}{1, 2, 3, 4, 5})
 }
 
 func (s *RethinkSuite) TestRowsScanMap(c *test.C) {
-	row := Expr(map[string]interface{}{
+	row, err := Expr(map[string]interface{}{
 		"id":   2,
 		"name": "Object 1",
 	}).RunRow(sess)
+	c.Assert(err, test.IsNil)
 
 	var response map[string]interface{}
-	err := row.Scan(&response)
+	err = row.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{
 		"id":   2,
@@ -49,13 +52,14 @@ func (s *RethinkSuite) TestRowsScanMap(c *test.C) {
 }
 
 func (s *RethinkSuite) TestRowsScanMapIntoInterface(c *test.C) {
-	row := Expr(map[string]interface{}{
+	row, err := Expr(map[string]interface{}{
 		"id":   2,
 		"name": "Object 1",
 	}).RunRow(sess)
+	c.Assert(err, test.IsNil)
 
 	var response interface{}
-	err := row.Scan(&response)
+	err = row.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{
 		"id":   2,
@@ -64,7 +68,7 @@ func (s *RethinkSuite) TestRowsScanMapIntoInterface(c *test.C) {
 }
 
 func (s *RethinkSuite) TestRowsScanMapNested(c *test.C) {
-	row := Expr(map[string]interface{}{
+	row, err := Expr(map[string]interface{}{
 		"id":   2,
 		"name": "Object 1",
 		"attr": []interface{}{map[string]interface{}{
@@ -72,9 +76,10 @@ func (s *RethinkSuite) TestRowsScanMapNested(c *test.C) {
 			"value": "value 1",
 		}},
 	}).RunRow(sess)
+	c.Assert(err, test.IsNil)
 
 	var response interface{}
-	err := row.Scan(&response)
+	err = row.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response, JsonEquals, map[string]interface{}{
 		"id":   2,
@@ -87,7 +92,7 @@ func (s *RethinkSuite) TestRowsScanMapNested(c *test.C) {
 }
 
 func (s *RethinkSuite) TestRowsScanStruct(c *test.C) {
-	row := Expr(map[string]interface{}{
+	row, err := Expr(map[string]interface{}{
 		"id":   2,
 		"name": "Object 1",
 		"Attrs": []interface{}{map[string]interface{}{
@@ -95,9 +100,10 @@ func (s *RethinkSuite) TestRowsScanStruct(c *test.C) {
 			"Value": "value 1",
 		}},
 	}).RunRow(sess)
+	c.Assert(err, test.IsNil)
 
 	var response object
-	err := row.Scan(&response)
+	err = row.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.DeepEquals, object{
 		Id:   2,
@@ -110,19 +116,21 @@ func (s *RethinkSuite) TestRowsScanStruct(c *test.C) {
 }
 
 func (s *RethinkSuite) TestRowsAtomString(c *test.C) {
-	row := Expr("a").RunRow(sess)
+	row, err := Expr("a").RunRow(sess)
+	c.Assert(err, test.IsNil)
 
 	var response string
-	err := row.Scan(&response)
+	err = row.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.Equals, "a")
 }
 
 func (s *RethinkSuite) TestRowsAtomArray(c *test.C) {
-	row := Expr([]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}).RunRow(sess)
+	row, err := Expr([]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}).RunRow(sess)
+	c.Assert(err, test.IsNil)
 
 	var response []int
-	err := row.Scan(&response)
+	err = row.Scan(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.DeepEquals, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 0})
 }
@@ -130,10 +138,12 @@ func (s *RethinkSuite) TestRowsAtomArray(c *test.C) {
 func (s *RethinkSuite) TestEmptyResults(c *test.C) {
 	DbCreate("test").Exec(sess)
 	Db("test").TableCreate("test").Exec(sess)
-	row := Db("test").Table("test").Get("missing value").RunRow(sess)
+	row, err := Db("test").Table("test").Get("missing value").RunRow(sess)
+	c.Assert(err, test.IsNil)
 	c.Assert(row.IsNil(), test.Equals, true)
 
-	row = Db("test").Table("test").Get("missing value").RunRow(sess)
+	row, err = Db("test").Table("test").Get("missing value").RunRow(sess)
+	c.Assert(err, test.IsNil)
 	var response interface{}
 	row.Scan(response)
 	c.Assert(row.IsNil(), test.Equals, true)


### PR DESCRIPTION
Fix error handling in RunRow as mentioned by @robert-zaremba in #11 and #16
