### PR TITLE
Options to reconnect on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,32 +78,32 @@ To view full documentation for the query functions check the [GoDoc](http://godo
 
 Slice Expr Example
 ```go
-r.Expr([]interface{}{1, 2, 3, 4, 5}).RunRow(conn)
+r.Expr([]interface{}{1, 2, 3, 4, 5}).RunRow(session)
 ```
 Map Expr Example
 ```go
-r.Expr(map[string]interface{}{"a": 1, "b": 2, "c": 3}).RunRow(conn)
+r.Expr(map[string]interface{}{"a": 1, "b": 2, "c": 3}).RunRow(session)
 ```
 Get Example
 ```go
-r.Db("database").Table("table").Get("GUID").RunRow(conn)
+r.Db("database").Table("table").Get("GUID").RunRow(session)
 ```
 Map Example (Func)
 ```go
 r.Expr([]interface{}{1, 2, 3, 4, 5}).Map(func (row RqlTerm) RqlTerm {
     return row.Add(1)
-}).Run(conn)
+}).Run(session)
 ```
 Map Example (Implicit)
 ```go
-r.Expr([]interface{}{1, 2, 3, 4, 5}).Map(r.Row.Add(1)).Run(conn)
+r.Expr([]interface{}{1, 2, 3, 4, 5}).Map(r.Row.Add(1)).Run(session)
 ```
 Between (Optional Args) Example
 ```go
 r.Db("database").Table("table").Between(1, 10, r.BetweenOpts{
     Index: "num",
     RightBound: "closed",
-}).Run(conn)
+}).Run(session)
 ```
 
 
@@ -126,7 +126,7 @@ Both ResultRows and ResultRow have the function `Scan` which is used to bind a r
 Example:
 
 ```go
-row, err := Table("tablename").Get(key).RunRow(conn)
+row, err := Table("tablename").Get(key).RunRow(session)
 if err != nil {
 	// error
 }
@@ -142,7 +142,7 @@ ResultRows also has the function `Next` which is used to iterate through a resul
 Example:
 
 ```go
-rows, err := Table("tablename").Run(conn)
+rows, err := Table("tablename").Run(session)
 if err != nil {
 	// error
 }

--- a/connection.go
+++ b/connection.go
@@ -221,12 +221,13 @@ func (c *Connection) SendQuery(s *Session, q *p.Query, t RqlTerm, opts map[strin
 // reconnects if configured to retry on failure
 func (c *Connection) reconnect(s *Session) bool {
 	for ; s.retries == -1 || c.attempts < s.retries; c.attempts++ {
-		time.Sleep(s.retryDelay)
 		c.Close()
+		time.Sleep(s.retryDelay)
 		if err := c.connect(s); err == nil {
 			c.attempts = 0
 			return true
 		}
 	}
+	c.Close()
 	return false
 }

--- a/connection.go
+++ b/connection.go
@@ -21,42 +21,54 @@ type Connection struct {
 	// embed the net.Conn type, so that we can effectively define new methods on
 	// it (interfaces do not allow that)
 	net.Conn
+	attempts int
 }
 
-// Reconnect closes the previous connection and attempts to connect again.
+// Dial opens a connection to the server
 func Dial(s *Session) (*Connection, error) {
+	c := new(Connection)
+	if err := c.connect(s); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// connects to the server, can be used for a new or existing connections
+// calling code is responsible for closing the existing connection
+func (c *Connection) connect(s *Session) error {
 	conn, err := net.Dial("tcp", s.address)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := binary.Write(conn, binary.LittleEndian, p.VersionDummy_V0_2); err != nil {
-		return nil, err
+		return err
 	}
 
 	// authorization key
 	if err := binary.Write(conn, binary.LittleEndian, uint32(len(s.authkey))); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := binary.Write(conn, binary.BigEndian, []byte(s.authkey)); err != nil {
-		return nil, err
+		return err
 	}
 
 	// read server response to authorization key (terminated by NUL)
 	reader := bufio.NewReader(conn)
 	line, err := reader.ReadBytes('\x00')
 	if err != nil {
-		return nil, err
+		return err
 	}
 	// convert to string and remove trailing NUL byte
 	response := string(line[:len(line)-1])
 	if response != "SUCCESS" {
 		// we failed authorization or something else terrible happened
-		return nil, RqlDriverError{fmt.Sprintf("Server dropped connection with message: \"%s\"", response)}
+		return RqlDriverError{fmt.Sprintf("Server dropped connection with message: \"%s\"", response)}
 	}
 
-	return &Connection{conn}, nil
+	c.Conn = conn
+	return nil
 }
 
 func (c *Connection) SendQuery(s *Session, q *p.Query, t RqlTerm, opts map[string]interface{}) (*ResultRows, error) {
@@ -79,12 +91,21 @@ func (c *Connection) SendQuery(s *Session, q *p.Query, t RqlTerm, opts map[strin
 	if data, err = proto.Marshal(q); err != nil {
 		return nil, err
 	}
-	if err = binary.Write(c, binary.LittleEndian, uint32(len(data))); err != nil {
-		return nil, err
-	}
+	for {
+		if err = binary.Write(c, binary.LittleEndian, uint32(len(data))); err != nil {
+			if c.reconnect(s) {
+				continue
+			}
+			return nil, err
+		}
 
-	if err = binary.Write(c, binary.BigEndian, data); err != nil {
-		return nil, err
+		if err = binary.Write(c, binary.BigEndian, data); err != nil {
+			if c.reconnect(s) {
+				continue
+			}
+			return nil, err
+		}
+		break
 	}
 
 	// Return immediately if the noreply option was set
@@ -192,4 +213,17 @@ func (c *Connection) SendQuery(s *Session, q *p.Query, t RqlTerm, opts map[strin
 	default:
 		return nil, RqlDriverError{fmt.Sprintf("Unexpected response type received: %s", r.GetType())}
 	}
+}
+
+// reconnects if configured to retry on failure
+func (c *Connection) reconnect(s *Session) bool {
+	for ; s.retries == -1 || c.attempts < s.retries; c.attempts++ {
+		time.Sleep(s.retryDelay)
+		c.Close()
+		if err := c.connect(s); err == nil {
+			c.attempts = 0
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Just getting my feet wet, maybe the feature or implementation makes no sense. Ignore if that's the case.

I noticed when restarted rethinkdb, the driver kept the failed connection alive. The only way to get it reconnected seemed to be to restart the app also, not ideal. I think this addresses some of the most common cases. Options, by default, maintain the existing behavior.
