### PR TITLE
Wrong indentation on func Connect breaking documentation page

### DIFF
--- a/session.go
+++ b/session.go
@@ -92,11 +92,11 @@ func (o *ConnectOpts) toMap() map[string]interface{} {
 // Basic connection example:
 //
 //	var session *r.Session
-// session, err := r.Connect(r.ConnectOpts{
-// 	Address:  "localhost:28015",
-// 	Database: "test",
-// 	AuthKey:  "14daak1cad13dj",
-// })
+// 	session, err := r.Connect(r.ConnectOpts{
+// 		Address:  "localhost:28015",
+// 		Database: "test",
+// 		AuthKey:  "14daak1cad13dj",
+// 	})
 func Connect(args ConnectOpts) (*Session, error) {
 	s := newSession(args.toMap())
 	err := s.Reconnect()


### PR DESCRIPTION
Hi, I noticed that the example on [func Connect](http://godoc.org/github.com/dancannon/gorethink#Connect) documentation is bit off.

Also, on line [162 of session.go](https://github.com/9uuso/gorethink/blob/master/session.go#L161) the function is documented to do the same as the function above. Is this an commenting error?
