### PR TITLE
Documentation update, use correct import fo go-check and resolve IsNil issue in One

### DIFF
--- a/gorethink_test.go
+++ b/gorethink_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 var sess *Session

--- a/query_aggregation_test.go
+++ b/query_aggregation_test.go
@@ -1,7 +1,7 @@
 package gorethink
 
 import (
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestAggregationReduce(c *test.C) {

--- a/query_control_test.go
+++ b/query_control_test.go
@@ -15,7 +15,7 @@ func (s *RethinkSuite) TestControlExecNil(c *test.C) {
 
 	err = res.One(&response)
 
-	c.Assert(err, test.IsNil)
+	c.Assert(err, test.Equals, ErrEmptyResult)
 	c.Assert(response, test.Equals, nil)
 }
 

--- a/query_control_test.go
+++ b/query_control_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestControlExecNil(c *test.C) {

--- a/query_db_test.go
+++ b/query_db_test.go
@@ -1,7 +1,7 @@
 package gorethink
 
 import (
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestDbCreate(c *test.C) {

--- a/query_join_test.go
+++ b/query_join_test.go
@@ -1,7 +1,7 @@
 package gorethink
 
 import (
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestJoinInnerJoin(c *test.C) {

--- a/query_manipulation_test.go
+++ b/query_manipulation_test.go
@@ -1,7 +1,7 @@
 package gorethink
 
 import (
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestManipulationDocField(c *test.C) {

--- a/query_math_test.go
+++ b/query_math_test.go
@@ -1,7 +1,7 @@
 package gorethink
 
 import (
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestMathAdd(c *test.C) {

--- a/query_select_test.go
+++ b/query_select_test.go
@@ -3,7 +3,7 @@ package gorethink
 import (
 	"fmt"
 
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestSelectGet(c *test.C) {

--- a/query_string_test.go
+++ b/query_string_test.go
@@ -1,7 +1,7 @@
 package gorethink
 
 import (
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestStringMatchSuccess(c *test.C) {

--- a/query_table_test.go
+++ b/query_table_test.go
@@ -3,7 +3,7 @@ package gorethink
 import (
 	"sync"
 
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestTableCreate(c *test.C) {

--- a/query_test.go
+++ b/query_test.go
@@ -1,6 +1,6 @@
 package gorethink
 
-import test "launchpad.net/gocheck"
+import test "gopkg.in/check.v1"
 
 func (s *RethinkSuite) TestQueryRun(c *test.C) {
 	var response string

--- a/query_time_test.go
+++ b/query_time_test.go
@@ -3,7 +3,7 @@ package gorethink
 import (
 	"time"
 
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestTimeTime(c *test.C) {

--- a/query_transformation.go
+++ b/query_transformation.go
@@ -34,7 +34,7 @@ func (o *OrderByOpts) toMap() map[string]interface{} {
 // Sort the sequence by document values of the given key(s).
 // To specify the index to use for ordering us a last argument in the following form:
 //
-//	map[string]interface{}{"index": "index-name"}
+//	OrderByOpts{Index: "index-name"}
 //
 // OrderBy defaults to ascending ordering. To explicitly specify the ordering,
 // wrap the attribute with either Asc or Desc.

--- a/query_transformation_test.go
+++ b/query_transformation_test.go
@@ -1,7 +1,7 @@
 package gorethink
 
 import (
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestTransformationMapImplicit(c *test.C) {

--- a/query_write_test.go
+++ b/query_write_test.go
@@ -1,7 +1,7 @@
 package gorethink
 
 import (
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestWriteInsert(c *test.C) {

--- a/results.go
+++ b/results.go
@@ -196,7 +196,7 @@ func (c *Cursor) All(result interface{}) error {
 	return c.Close()
 }
 
-// All retrieves a single document from the result set into the provided
+// One retrieves a single document from the result set into the provided
 // slice and closes the cursor.
 func (c *Cursor) One(result interface{}) error {
 	ok := c.Next(result)

--- a/results.go
+++ b/results.go
@@ -199,6 +199,9 @@ func (c *Cursor) All(result interface{}) error {
 // One retrieves a single document from the result set into the provided
 // slice and closes the cursor.
 func (c *Cursor) One(result interface{}) error {
+	if c.IsNil() {
+		return ErrEmptyResult
+	}
 	ok := c.Next(result)
 	if !ok {
 		err := c.Err()

--- a/results_test.go
+++ b/results_test.go
@@ -163,7 +163,8 @@ func (s *RethinkSuite) TestEmptyResults(c *test.C) {
 	res, err = Db("test").Table("test").Get("missing value").Run(sess)
 	c.Assert(err, test.IsNil)
 	var response interface{}
-	res.One(&response)
+	err = res.One(&response)
+	c.Assert(err, test.Equals, ErrEmptyResult)
 	c.Assert(res.IsNil(), test.Equals, true)
 
 	res, err = Db("test").Table("test").Get("missing value").Run(sess)

--- a/results_test.go
+++ b/results_test.go
@@ -1,6 +1,6 @@
 package gorethink
 
-import test "launchpad.net/gocheck"
+import test "gopkg.in/check.v1"
 
 type object struct {
 	Id    int64  `gorethink:"id,omitempty"`

--- a/session_test.go
+++ b/session_test.go
@@ -3,7 +3,7 @@ package gorethink
 import (
 	"os"
 
-	test "launchpad.net/gocheck"
+	test "gopkg.in/check.v1"
 )
 
 func (s *RethinkSuite) TestSessionConnect(c *test.C) {

--- a/wercker.yml
+++ b/wercker.yml
@@ -16,7 +16,7 @@ build:
           code: |
             cd $WERCKER_SOURCE_DIR
             go version
-            go get ./... && go get -u launchpad.net/gocheck && go test -i
+            go get ./... && go get -u gopkg.in/check.v1 && go test -i
 
       # Build the project
       - script:


### PR DESCRIPTION
Commits messages are quite verbose.

gocheck package has been moved to github, and it should be (according to it's author) referenced by gopkg.in/check.v1

In last commit, I've changed a bit behaviour of `cursor.One`. For me it was clear that I need to call `IsNil` every time I'm using `One`. Since `One` looks to be more higher level, and already uses `ErrEmptyResult` then it's logical that it should also support empty results as is.
