### PR TITLE
GetAll for multiple ids

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -31,7 +31,12 @@ func constructRootTerm(name string, termType p.Term_TermType, args []interface{}
 // this function adds the previous expression in the tree to the argument list to
 // create a method term.
 func constructMethodTerm(prevVal Term, name string, termType p.Term_TermType, args []interface{}, optArgs map[string]interface{}) Term {
-	args = append([]interface{}{prevVal}, args...)
+
+	if len(args) > 0 && reflect.TypeOf(args[0]).Kind() == reflect.Slice {
+		args = append([]interface{}{prevVal}, args[0].([]interface{})...)
+	} else {
+		args = append([]interface{}{prevVal}, args...)
+	}
 
 	return Term{
 		name:     name,


### PR DESCRIPTION
Hello.
I'm not sure, i'm understanding it right. But I couldn't find a way to construct query to `GetAll()` method. For example, you have to find several keys from the user input. What is the proper way to do it?

I've done some simple fix, which lets to pass slices to GetAll, e.g.

``` go
r.Table("users").GetAll([]interface{}{
    "348c4c7d-631e-41ce-bece-942d70385bd3", 
    "0a56526c-bd7b-4f87-bf05-d42b5a07e297"}).Run(session)
```
